### PR TITLE
Empty print statement caused compile time error

### DIFF
--- a/src/nnTest.f90
+++ b/src/nnTest.f90
@@ -91,7 +91,7 @@ program nnTest
 
         ! check nn derivative of weights with finitie difference
         print*, sum(dParams*dxParams) / sqrt(sum(dParams**2)), '?=', sum(out2 - out1) / sqrt(sum(dParams**2))
-        print*,
+        print*, " "
 
     end if
 


### PR DESCRIPTION
Gfortran 11.3.0 says: 

   94 |         print*,
      |               1
Error: Comma after * at (1) not allowed without I/O list

Can be fixed by either printing a space, for skipping a line, or removing the entire print statement. Suggested fix is printing a space.